### PR TITLE
guard against nil transition only.

### DIFF
--- a/addon/initializers/route-layers.js
+++ b/addon/initializers/route-layers.js
@@ -15,7 +15,7 @@ export function initialize () {
     afterModel: function (model, transition) {
       this._super(...arguments);
 
-      if (!model || !transition) { return; }
+      if (!transition) { return; }
 
       // Leaf route only
       var leafRouteName = Ember.A(transition.handlerInfos).get('lastObject.handler.routeName');


### PR DESCRIPTION
Some routes correctly have no model and should still be pushed to the stack.
Fixes #21.
